### PR TITLE
Fix handling ssh-config of multi-vm files

### DIFF
--- a/lib/vagrant_mutagen_utilizer/orchestrator.rb
+++ b/lib/vagrant_mutagen_utilizer/orchestrator.rb
@@ -87,10 +87,11 @@ module VagrantPlugins
       end
 
       def ssh_config_entry
+        name = @machine.name
         hostname = @machine.config.vm.hostname
 
         # Get the SSH config from Vagrant
-        sshconfig = `vagrant ssh-config --host #{hostname}`
+        sshconfig = `vagrant ssh-config --host #{hostname} #{name}`
         # Trim Whitespace from end
         sshconfig = sshconfig.gsub(/^$\n/, '')
         sshconfig = sshconfig.chomp


### PR DESCRIPTION
When using a Vagrantfile with multiple declared machines, saved ssh-config is wrong.

Currently, this call is done: `vagrant ssh-config --host #{hostname}`. The `host` parameter tell Vagrant how to name the entry.
With machines `db` and `app`, and respective hostnames `project-db` and `project-app`, the result for each looks like:
```
# VAGRANT: hash (db) / uuid
Host project-db
  HostName 127.0.0.1
  User vagrant
  Port 2222
  […]
Host project-db
  HostName 127.0.0.1
  User vagrant
  Port 2201
  […]
# VAGRANT: hash (db) / uuid
# VAGRANT: hash (app) / uuid
Host project-app
  HostName 127.0.0.1
  User vagrant
  Port 2222
  […]
Host project-app
  HostName 127.0.0.1
  User vagrant
  Port 2201
  […]
# VAGRANT: hash (app) / uuid
```
Which does not work well.

To fix this, it is required to add the machine name to the `ssh-config` call. Which results to `vagrant ssh-config --host #{hostname} #{name}` and a clean ssh-config file :
```
# VAGRANT: hash (db) / uuid
Host project-db
  HostName 127.0.0.1
  User vagrant
  Port 2222
  […]
# VAGRANT: hash (db) / uuid
# VAGRANT: hash (app) / uuid
Host project-app
  HostName 127.0.0.1
  User vagrant
  Port 2201
  […]
# VAGRANT: hash (app) / uuid
```
